### PR TITLE
fix: Support changed js-ipfs 0.41 constructor api

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion) web extension provides a [`window.ipfs` object](https://github.com/ipfs-shipyard/ipfs-companion/blob/master/docs/window.ipfs.md) to web pages you visit.
 
-This module will detects the presence of `window.ipfs` and automatically falls back to downloading the latest version of IPFS from `https://unpkg.com/ipfs/dist/index.min.js` if it's unavailable. Note: can be configured to fallback to IPFS API.
+This module will detects the presence of `window.ipfs` and automatically falls back to downloading the latest version of IPFS from `https://unpkg.com/ipfs/dist/index.min.js` if it's unavailable. Note: can be configured to fallback to IPFS HTTP Client.
 
 ## Usage
 
@@ -30,7 +30,7 @@ If `window.ipfs` is unavailable, a `<script src="https://unpkg.com/ipfs/dist/ind
 
 * `options.cdn` - (String) URL of a CDN to load IPFS from. Use this option if you want to use a different CDN, or request a specific version, or a non-minifed version
 * `options.ipfs` - (Object) Options to pass to the fallback [IPFS constructor](https://github.com/ipfs/js-ipfs#ipfs-constructor)
-* `options.api` - (Boolean) Fallback to IPFS API (https://unpkg.com/ipfs-api/dist/index.min.js by default)
+* `options.api` - (Boolean) Fallback to IPFS API (https://unpkg.com/ipfs-http-client/dist/index.min.js by default)
 
 ## Contribute
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2212,7 +2212,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2233,12 +2234,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2253,17 +2256,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2380,7 +2386,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2392,6 +2399,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2406,6 +2414,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2413,12 +2422,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2437,6 +2448,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2517,7 +2529,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2529,6 +2542,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2614,7 +2628,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2650,6 +2665,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2669,6 +2685,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2712,12 +2729,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3888,6 +3907,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4212,7 +4232,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -4296,6 +4317,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4342,7 +4364,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -4608,7 +4631,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "npm run lint && npm run test:ava",
     "test:ava": "nyc --reporter=lcov --reporter=text ava",
-    "lint": "standard"
+    "lint": "standard",
+    "lint:fix": "standard --fix"
   },
   "author": "Alan Shaw",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -13,41 +13,37 @@ test.serial('should use window.ipfs if available', async t => {
 })
 
 test.serial('should use window.ipfs.enable if available', async t => {
-  window.ipfs = { enable: async (args) => args }
-  const permissions = Object.freeze({ foo: ['a', 'b', 'c'], bar: ['1', '2', '3'], buzz: false })
+  window.ipfs = { enable: async args => args }
+  const permissions = Object.freeze({
+    foo: ['a', 'b', 'c'],
+    bar: ['1', '2', '3'],
+    buzz: false
+  })
   const ipfs = await getIpfs({ permissions })
   t.deepEqual(ipfs, permissions)
 })
 
 test.serial('should use window.Ipfs if available', async t => {
-  const instance = {
-    once (event, handler) {
-      if (event === 'ready') process.nextTick(() => handler())
-      return instance
-    },
-    removeListener: () => instance
-  }
+  const instance = {}
 
-  window.Ipfs = function () { return instance }
+  window.Ipfs = {
+    create: () => instance
+  }
 
   const ipfs = await getIpfs()
   t.is(ipfs, instance)
 })
 
 test.serial('should load IPFS from CDN if window.ipfs unavailable', async t => {
-  const instance = {
-    once (event, handler) {
-      if (event === 'ready') process.nextTick(() => handler())
-      return instance
-    },
-    removeListener: () => instance
-  }
+  const instance = {}
 
   document.createElement = () => ({})
   document.body = {
     appendChild (el) {
       process.nextTick(() => {
-        window.Ipfs = function () { return instance }
+        window.Ipfs = {
+          create: () => instance
+        }
         el.onload()
       })
     }
@@ -57,14 +53,16 @@ test.serial('should load IPFS from CDN if window.ipfs unavailable', async t => {
   t.is(ipfs, instance)
 })
 
-test.serial('should load IPFS API', async t => {
+test.serial('should load IPFS HTTP Client', async t => {
   const instance = {}
 
   document.createElement = () => ({})
   document.body = {
     appendChild (el) {
       process.nextTick(() => {
-        window.IpfsApi = function () { return instance }
+        window.IpfsHttpClient = function () {
+          return instance
+        }
         el.onload()
       })
     }


### PR DESCRIPTION
js-ipfs 0.41 switches from initializing an ipfs node through a constructor to a static factory method, so the initialisation has been changed to support the latest version of js-ipfs being loaded over the cdn.

This commit also swaps from using `IPFS-API` for `IPFS-HTTP-Client`, as the library is now been renamed.